### PR TITLE
Allow filtering by strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,21 @@ This is used as any browserify transform, apply it with `browserify.transform` i
 `package.json`, with the `-t` or `-g` flag on the CLI, with `b.transform()`…
 
 _*IMPORTANT NOTE*_: in order for this to actually work, it needs to run _after_ Uglify.
+
+## Options
+
+You can prevent files from being optimized by passing a filter RegExp or string
+
+``` javascript
+var bundler = browserify('index.js')
+
+bundler.transform('optimizify', { filter: /.json/ })
+  .bundle()
+  .pipe(process.stdout)
+```
+
+or
+
+``` javascript
+browserify -g [ optimizify --filter '.json' ] ./index.js
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can prevent files from being optimized by passing a filter RegExp or string
 ``` javascript
 var bundler = browserify('index.js')
 
-bundler.transform('optimizify', { filter: /.json/ })
+bundler.transform('optimizify', { filter: /\.json/ })
   .bundle()
   .pipe(process.stdout)
 ```

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var through2 = require('through2')
 function optimizify (file, options) {
     options = options || {};
     var filter = options.filter;
+    if (typeof filter === 'string') { filter = new RegExp(filter); }
     if (filter && !filter.test(file)) return through2();
 
     return through2(


### PR DESCRIPTION
Hi there, we love your tool and depend on it for our production deploys, _however_ it looks like the upstream OptimizeJS project chokes on JSON files. Since we use browserify via the commandline, we need a way to filter JSON files out of the pipeline.

This PR documents the filter option your pipeline uses, as well as allows passing a string as a filter, so that we can use this as part of our project.

Thoughts?